### PR TITLE
Improve c++ support

### DIFF
--- a/themes/sublime-monokai-color-theme.json
+++ b/themes/sublime-monokai-color-theme.json
@@ -552,6 +552,45 @@
 				"foreground": "#66D9EF"
 			}
 		},
+		{
+			"name": "Namespace name",
+			"scope": "entity.name.namespace.cpp",
+			"settings": {
+				"foreground": "#A6E22E",
+			}
+		},
+		{
+			"name": "Namespace keyword",
+			"scope": "storage.type.namespace.definition.cpp",
+			"settings": {
+				"foreground": "#F92672",
+				"fontStyle": ""
+			}
+		},
+		{
+			"name": "Access modifier keyword",
+			"scope": "storage.type.modifier.access",
+			"settings": {
+					"foreground": "#F92672",
+					"fontStyle": ""
+			}
+		},
+		{
+			"name": "Access modifier colon",
+			"scope": "punctuation.separator.colon.access.control.cpp",
+			"settings": {
+				"foreground": "#F8F8F2",
+			}
+		},
+		{
+			// Not perfect, but the best we can do without updating C++ language support
+			"name": "Inherited class",
+			"scope": "meta.qualified_type.cpp, entity.name.type.cpp",
+			"settings": {
+				"fontStyle": "italic",
+				"foreground": "#A6E22E"
+			}
+		},
 		// Second class C support
 		{
 			"name": "Sublime C White highlights",


### PR DESCRIPTION
Improve namespace and class declarations to better match Sublime.

before:
![Screen Shot 2021-11-26 at 3 41 34 PM](https://user-images.githubusercontent.com/20860653/143655785-3d5fb78b-0765-427b-abe7-132d61c21f45.png)

after: 
![Screen Shot 2021-11-26 at 3 54 14 PM](https://user-images.githubusercontent.com/20860653/143655670-ac1c9ab2-f39b-4aa7-8b35-86eb192636fe.png)

compare with sublime:
<img width="714" alt="Screen Shot 2021-11-26 at 3 42 23 PM" src="https://user-images.githubusercontent.com/20860653/143655765-d3b27447-ca1e-4370-a7d9-afdf9f3d9c24.png">

This is still the closest to Sublime's theming. Thanks for putting it together!

