### PR TITLE
Support C# file scoped namespaces

### DIFF
--- a/syntaxes/csharp.tmLanguage.json
+++ b/syntaxes/csharp.tmLanguage.json
@@ -519,7 +519,7 @@
 					"name": "keyword.other.namespace.cs"
 				}
 			},
-			"end": "(?<=\\})",
+			"end": "(?<=\\}|;)",
 			"patterns": [
 				{
 					"include": "#comment"


### PR DESCRIPTION
Adding support for [File scoped namespaces](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-10.0/file-scoped-namespaces) added in C# 10.

## Before
![Screenshot 2022-06-29 194215](https://user-images.githubusercontent.com/42574977/176518271-da13b338-c1c1-48c0-8af8-758549be7117.png)

## After
![Screenshot 2022-06-29 201030](https://user-images.githubusercontent.com/42574977/176518331-c67ecea3-6d90-4c1b-a7d5-1b654f1c5386.png)
